### PR TITLE
pedantic NULL-safety

### DIFF
--- a/trim.c
+++ b/trim.c
@@ -14,7 +14,7 @@ void usage(){
 }
 
 char *ltrim(char *dest, const char *c){
-  if(! (strlen(dest) && strlen(c))) return dest;
+  if(! (dest && strlen(dest) && c && strlen(c))) return dest;
   int cPos = 0;
 
   do{
@@ -30,7 +30,7 @@ char *ltrim(char *dest, const char *c){
 }
 
 char *rtrim(char *dest, const char *c){
-  if(! (strlen(dest) && strlen(c))) return dest;
+  if(! (dest && strlen(dest) && c && strlen(c))) return dest;
   int cPos = 0;
 
   do{


### PR DESCRIPTION
strlen is not expected to be NULL-safe, as demonstrated by a simple test with glibc on linux:

    eric@titan:~/src/trim$ cat > pedantic.c <<EOF
    > #include <stdio.h>
    > #include <string.h>
    > int main(void)
    > {
    >   char *c = "foo";
    >   fprintf(stderr, "len %s: %lu\n", c, (unsigned long) strlen(c));
    >   c = NULL;
    >   fprintf(stderr, "len %s: %lu\n", c, (unsigned long) strlen(c));
    >   return 0;
    > }
    > EOF
    eric@titan:~/src/trim$ gcc pedantic.c
    eric@titan:~/src/trim$ ./a.out 
    len foo: 3
    Segmentation fault
    eric@titan:~/src/trim$`

This commit simply checks for non-NULL-ness of the pointers before passing them to strlen.